### PR TITLE
added marshal eviction data

### DIFF
--- a/src/nycdb/dataset_transformations.py
+++ b/src/nycdb/dataset_transformations.py
@@ -60,3 +60,6 @@ def acris(dataset, schema):
         return skip_fields(_to_csv, [s.lower() for s in schema['skip']])
     else:
         return _to_csv
+
+def marshal_evictions_17(dataset):
+    return to_csv(dataset.files[0].dest)

--- a/src/nycdb/datasets.yml
+++ b/src/nycdb/datasets.yml
@@ -917,4 +917,29 @@ acris:
           UCCCOLLATERALCODE: char(1)
           DESCRIPTION: text
 
-
+marshal_evictions_17:
+  files:
+    -
+      url: https://s3.amazonaws.com/justfix-data/marshal_evictions_2017.csv
+      dest: marshal_evictions_17.csv 
+  schema:
+    table_name: marshal_evictions_17
+    fields:
+      boro: text
+      courtindex: text
+      docketnumber: text
+      evictionaddress: text
+      apt: text
+      zip: text
+      uniqueid: text
+      executeddate: date
+      marshalfirstname: text
+      marshallastname: text
+      evictiontype: text
+      scheduledstatus: text
+      cleanedaddress1: text
+      lat: numeric
+      lng: numeric
+      geocoder: text
+      cleanedaddress2: text
+      bbl: char(10)

--- a/src/nycdb/verify.py
+++ b/src/nycdb/verify.py
@@ -34,7 +34,8 @@ TABLES = {
         'acris_document_control_codes': 123,
         'acris_property_type_codes': 46,
         'acris_ucc_collateral_codes': 8
-    }
+    },
+    'marshal_evictions_17': {'marshal_evictions_17': 17000} 
 }
 
 


### PR DESCRIPTION
Adding in 2017 eviction data to nycdb. Data was sourced from NYC Marshals and cleaned by the Housing Data Coalition (housingdatacoalition@gmail.com). We also geocoded the data and appended BBLs. Hooray! 