### PR TITLE
hpd contacts strange char data bug fix

### DIFF
--- a/src/nycdb/datasets.yml
+++ b/src/nycdb/datasets.yml
@@ -542,6 +542,7 @@ hpd_registrations:
     - hpd_registrations/anyarray_uniq.sql
     - hpd_registrations/anyarray_remove_null.sql
     - hpd_registrations/first_last.sql
+    - hpd_registrations/contacts_cleanup.sql
     - hpd_registrations/corporate_owners.sql
     - hpd_registrations/business_addrs.sql
     - hpd_registrations/registrations_grouped_by_bbl.sql

--- a/src/nycdb/sql/hpd_registrations/contacts_cleanup.sql
+++ b/src/nycdb/sql/hpd_registrations/contacts_cleanup.sql
@@ -1,0 +1,16 @@
+
+-- Null out values consisting purely of non-alphanumeric chars (\W), X's, and/or whitespace (\s)
+UPDATE hpd_contacts SET contactdescription = nullif(regexp_replace(contactdescription,'^(\W|X|\s)*$', ''),'');
+UPDATE hpd_contacts SET corporationname = nullif(regexp_replace(corporationname,'^(\W|X|\s)*$', ''),'');
+UPDATE hpd_contacts SET title = nullif(regexp_replace(title,'^(\W|X|\s)*$', ''),'');
+UPDATE hpd_contacts SET firstname = nullif(regexp_replace(firstname,'^(\W|X|\s)*$', ''),'');
+UPDATE hpd_contacts SET lastname = nullif(regexp_replace(lastname,'^(\W|X|\s)*$', ''),'');
+UPDATE hpd_contacts SET businesshousenumber = nullif(regexp_replace(businesshousenumber,'^(\W|X|\s)*$', ''),'');
+UPDATE hpd_contacts SET businessstreetname = nullif(regexp_replace(businessstreetname,'^(\W|X|\s)*$', ''),'');
+UPDATE hpd_contacts SET businessapartment = nullif(regexp_replace(businessapartment,'^(\W|X|\s)*$', ''),'');
+UPDATE hpd_contacts SET businesscity = nullif(regexp_replace(businesscity,'^(\W|X|\s)*$', ''),'');
+UPDATE hpd_contacts SET businessstate = nullif(regexp_replace(businessstate,'^(\W|X|\s)*$', ''),'');
+UPDATE hpd_contacts SET businesszip = nullif(regexp_replace(businesszip,'^(\W|X|\s)*$', ''),'');
+
+-- Null out middle initials that aren't letters, @, or & (which apparently people use...)
+UPDATE hpd_contacts SET middleinitial = nullif(regexp_replace(middleinitial,'^[^a-zA-Z@&]*$', ''),'');


### PR DESCRIPTION
- added a new sql file to the db build process that scans through most columns in hpd_contacts and replaces values made up of non-alphanumeric chars, X's, and whitespace with nulls
- the cleaning file does something slightly different for the 'middleinitial' field (apparently, some folks register as two names with an & as the middle initial...)
- perhaps there's a more elegant way to do this? Open to suggestions